### PR TITLE
fix run from ide, copy vJoyInterface.dll part of the build

### DIFF
--- a/vJoySerialFeeder/vJoySerialFeeder.csproj
+++ b/vJoySerialFeeder/vJoySerialFeeder.csproj
@@ -140,5 +140,11 @@
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <ContentWithTargetPath Include="Lib\vJoy_x86\vJoyInterface.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <TargetPath>vJoyInterface.dll</TargetPath>
+    </ContentWithTargetPath>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
I tried to run from ide (sharpdevelop 4.4 and Visual studio 2017) but I always got vJoyInterface.dll is missing error. If i copy the dll next to exe it runs with out error.
Now vJoyInterface.dll will be copied to output folder as part of the build. So now we can simply run /debug from ide with any manual coping.
I hope like it ;)  