### PR TITLE
Add CrsfReader serial reader for Crossfire serial

### DIFF
--- a/vJoySerialFeeder/MainForm.Designer.cs
+++ b/vJoySerialFeeder/MainForm.Designer.cs
@@ -295,8 +295,8 @@ namespace vJoySerialFeeder
         	        	        	"SBUS",
         	        	        	"FPort",
         	        	        	"DSM",
-        	        	        	"Dummy",
-        	        	        	"CRSF"});
+        	        	        	"CRSF",
+        	        	        	"Dummy"});
         	this.comboProtocol.Location = new System.Drawing.Point(360, 64);
         	this.comboProtocol.Name = "comboProtocol";
         	this.comboProtocol.Size = new System.Drawing.Size(72, 21);

--- a/vJoySerialFeeder/MainForm.Designer.cs
+++ b/vJoySerialFeeder/MainForm.Designer.cs
@@ -295,7 +295,8 @@ namespace vJoySerialFeeder
         	        	        	"SBUS",
         	        	        	"FPort",
         	        	        	"DSM",
-        	        	        	"Dummy"});
+        	        	        	"Dummy",
+        	        	        	"CRSF"});
         	this.comboProtocol.Location = new System.Drawing.Point(360, 64);
         	this.comboProtocol.Name = "comboProtocol";
         	this.comboProtocol.Size = new System.Drawing.Size(72, 21);

--- a/vJoySerialFeeder/MainForm.cs
+++ b/vJoySerialFeeder/MainForm.cs
@@ -57,8 +57,8 @@ namespace vJoySerialFeeder
 										typeof(SbusReader),
 										typeof(FportReader),
 										typeof(DsmReader),
-										typeof(DummyReader),
-										typeof(CrsfReader)
+										typeof(CrsfReader),
+										typeof(DummyReader)
 									};
 		
 		private ComAutomation comAutomation;

--- a/vJoySerialFeeder/MainForm.cs
+++ b/vJoySerialFeeder/MainForm.cs
@@ -57,7 +57,8 @@ namespace vJoySerialFeeder
 										typeof(SbusReader),
 										typeof(FportReader),
 										typeof(DsmReader),
-										typeof(DummyReader)
+										typeof(DummyReader),
+										typeof(CrsfReader)
 									};
 		
 		private ComAutomation comAutomation;

--- a/vJoySerialFeeder/SerialProtocols/CrsfReader.cs
+++ b/vJoySerialFeeder/SerialProtocols/CrsfReader.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections;
+using System.IO.Ports;
+using System.Windows.Forms;
+
+namespace vJoySerialFeeder
+{
+	public class Crc8
+	{
+		private byte[] _table = new byte[256];
+
+		public Crc8(byte poly)
+		{
+			GenerateTable(poly);
+			Out = 0;
+		}
+
+		public void Add(byte b)
+		{
+			_out = _table[_out ^ b];
+		}
+
+		private byte _out = 0;
+		public byte Out
+		{
+			get { return _out;  }
+			set { _out = 0;  }
+		}
+
+		private void GenerateTable(byte poly)
+		{
+			for (uint i = 0; i < 256; ++i)
+			{
+				uint curr = i;
+				for (uint j = 0; j < 8; ++j)
+				{
+					if ((curr & 0x80) != 0)
+					{
+						curr = (curr << 1) ^ poly;
+					}
+					else
+					{
+						curr <<= 1;
+					}
+				}
+
+				_table[i] = (byte)curr;
+			}
+		}
+	}
+
+	public class CrsfReader : SerialReader
+	{
+		const int CRSF_PAYLOAD_SIZE_MAX = 62;
+		const int CRSF_SUBSET_RC_CHANNELS_PACKED_RESOLUTION = 11; // 11 bits per channel
+		const uint CRSF_SUBSET_RC_CHANNELS_PACKED_MASK = 0b11111111111; // 11 bits, get it?!
+
+		// AddressTypes
+		const byte CRSF_ADDRESS_FLIGHT_CONTROLLER = 0xC8; // 200
+		// FrameTypes
+		const byte CRSF_FRAMETYPE_LINK_STATISTICS = 0x14;
+		const byte CRSF_FRAMETYPE_RC_CHANNELS_PACKED = 0x16;
+
+		private Crc8 crcCalc = new Crc8(0xD5);
+
+		public override void Start()
+		{
+			serialPort.ReadTimeout = 500;
+			Buffer.FrameLength = CRSF_PAYLOAD_SIZE_MAX + 2;
+		}
+
+		public override void Stop()
+		{
+		}
+
+		public override int ReadChannels()
+		{
+			int retVal = 0;
+			byte len = Buffer[1];
+			byte addr = Buffer[0];
+			//System.Diagnostics.Debug.WriteLine("CRSF[{0}] len={1}", addr, len);
+			if (len < 1 || len > CRSF_PAYLOAD_SIZE_MAX)
+			{
+				Buffer.Slide(2);
+				return 0;
+			}
+
+
+			// Read the whole frame up to the CRC byte
+			crcCalc.Out = 0;
+			for (int payloadIdx=0; payloadIdx < len - 1; ++payloadIdx)
+				crcCalc.Add(Buffer[payloadIdx + 2]);
+
+			byte inCrc = Buffer[2 + len - 1];
+			if (crcCalc.Out != inCrc)
+			{
+				System.Diagnostics.Debug.WriteLine("Bad checksum {0:X} calced {1:X}", inCrc, crcCalc.Out);
+			}
+			else
+			{
+				//System.Diagnostics.Debug.WriteLine("CRSF packet type={0:X}", Buffer[2]);
+				if ((Buffer[0] == CRSF_ADDRESS_FLIGHT_CONTROLLER)
+					&& (Buffer[2] == CRSF_FRAMETYPE_RC_CHANNELS_PACKED))
+				{
+					const uint numOfChannels = 16;
+					uint readByte = 0;
+					int byteIndex = 3;
+					int bitsMerged = 0;
+					uint readValue = 0;
+					for (uint n = 0; n < numOfChannels; n++)
+					{
+						while (bitsMerged < CRSF_SUBSET_RC_CHANNELS_PACKED_RESOLUTION)
+						{
+							readByte = Buffer[byteIndex++];
+							readValue |= readByte << bitsMerged;
+							bitsMerged += 8;
+						}
+
+						channelData[n] = (int)map((readValue & CRSF_SUBSET_RC_CHANNELS_PACKED_MASK), 191, 1792, 1000, 2000);
+						readValue >>= CRSF_SUBSET_RC_CHANNELS_PACKED_RESOLUTION;
+						bitsMerged -= CRSF_SUBSET_RC_CHANNELS_PACKED_RESOLUTION;
+					}
+
+					//System.Diagnostics.Debug.WriteLine("Roll={0}", channelData[0]);
+					retVal = (int)numOfChannels;
+				} /* if packed channels */
+			} /* if valid checksum */
+
+			Buffer.Slide(2 + len + 1);
+			return retVal;
+		}
+
+		public override Configuration.SerialParameters GetDefaultSerialParameters()
+		{
+			return new Configuration.SerialParameters()
+			{
+				BaudRate = 420000,
+				DataBits = 8,
+				Parity = Parity.None,
+				StopBits = StopBits.One
+			};
+		}
+
+		public override bool Configurable { get { return false; } }
+
+		static private uint map(uint val, uint in_min, uint in_max, uint out_min, uint out_max)
+		{
+			// constrain(retVal, out_min, out_max)
+			if (val < in_min)
+				return out_min;
+			if (val > in_max)
+				return out_max;
+			return (val - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
+
+		}
+	}
+}

--- a/vJoySerialFeeder/SerialProtocols/CrsfReader.cs
+++ b/vJoySerialFeeder/SerialProtocols/CrsfReader.cs
@@ -79,9 +79,9 @@ namespace vJoySerialFeeder
 			byte len = Buffer[1];
 			byte addr = Buffer[0];
 			//System.Diagnostics.Debug.WriteLine("CRSF[{0}] len={1}", addr, len);
-			if (len < 1 || len > CRSF_PAYLOAD_SIZE_MAX)
+			if (len < 2 || len > CRSF_PAYLOAD_SIZE_MAX)
 			{
-				Buffer.Slide(2);
+				Buffer.Slide(1);
 				return 0;
 			}
 

--- a/vJoySerialFeeder/vJoySerialFeeder.csproj
+++ b/vJoySerialFeeder/vJoySerialFeeder.csproj
@@ -250,6 +250,13 @@
       <TargetPath>msvcr120.dll</TargetPath>
     </ContentWithTargetPath>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Mappings" />
+    <Folder Include="ProcessInteraction" />
+    <Folder Include="Scripting" />
+    <Folder Include="SerialProtocols" />
+    <Folder Include="VirtualJoysticks" />
+    <Folder Include="VirtualJoysticks" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/vJoySerialFeeder/vJoySerialFeeder.csproj
+++ b/vJoySerialFeeder/vJoySerialFeeder.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Scripting\LuaOutputForm.Designer.cs">
       <DependentUpon>LuaOutputForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="SerialProtocols\CrsfReader.cs" />
     <Compile Include="SerialProtocols\DsmReader.cs" />
     <Compile Include="SerialProtocols\DummyReader.cs" />
     <Compile Include="SerialProtocols\DummySetupForm.cs" />
@@ -249,13 +250,6 @@
       <TargetPath>msvcr120.dll</TargetPath>
     </ContentWithTargetPath>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Mappings" />
-    <Folder Include="ProcessInteraction" />
-    <Folder Include="Scripting" />
-    <Folder Include="SerialProtocols" />
-    <Folder Include="VirtualJoysticks" />
-    <Folder Include="VirtualJoysticks" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
I am an ExpressLRS developer and one of our users asked us to support IBUS output so people would be able to use ExpressLRS with vJoySerialFeeder but I say why make our stuff support that if I can make someone else support us instead? 😄 

This PR adds CRSF protocol support to vJoySerialFeeder. It should work with any Crossfire receiver, with just the TX wire to an RX on the FTDI connector. I only tested it with one running ExpressLRS though.
![vJoyELRS](https://user-images.githubusercontent.com/677183/116343604-c10ffd80-a7b2-11eb-9007-0992682fef06.gif)

Your architecture is fantastic, it took me only 30 minutes to get this done and like an hour of trying to prevent my Visual Studio from reorganizing all your code when I tried to add a single line. I was largely successful in that, but let me know if something didn't work out. I swear it was a nightmare.

